### PR TITLE
NTR: Add getCategoryIdByName in Helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added new helper method `getCategoryIdByName()`
+
 ## [1.8.0] - 2022-06-03
 ### Added
 - Added FixtureTrait

--- a/src/FixtureHelper.php
+++ b/src/FixtureHelper.php
@@ -227,4 +227,23 @@ class FixtureHelper
             ->searchIds($criteria, Context::createDefaultContext())
             ->firstId();
     }
+
+    /**
+     * Gets the first ID of the first found category
+     * with the provided name.
+     *
+     * @param string $name
+     * @return string|null
+     */
+    public function getCategoryIdByName(string $name): ?string
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->setLimit(1);
+
+        return $this->categoryRepository
+            ->searchIds($criteria, Context::createDefaultContext())
+            ->firstId();
+    }
+
 }

--- a/src/FixtureHelper.php
+++ b/src/FixtureHelper.php
@@ -231,9 +231,6 @@ class FixtureHelper
     /**
      * Gets the first ID of the first found category
      * with the provided name.
-     *
-     * @param string $name
-     * @return string|null
      */
     public function getCategoryIdByName(string $name): ?string
     {
@@ -245,5 +242,4 @@ class FixtureHelper
             ->searchIds($criteria, Context::createDefaultContext())
             ->firstId();
     }
-
 }


### PR DESCRIPTION
With the Shopware Demo data I wasn't able to easily display a product in the storefront,
because the provided helper functions lead to root-level categories that where somehow not displayed.

I've created a getCategoryByName which turned out to work and is easy to use.
Would be cool if that could be added.

`
$id = $this->helper->getCategoryIdByName('Clothing');
`