### PR TITLE
NTR: Add Media Upload Helper

### DIFF
--- a/src/FixtureHelper.php
+++ b/src/FixtureHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Basecom\FixturePlugin;
 
+use Basecom\FixturePlugin\Utils\MediaUtils;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\InvoicePayment;
 use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderEntity;
 use Shopware\Core\Defaults;
@@ -28,6 +29,7 @@ class FixtureHelper
     private EntityRepositoryInterface $taxRepository;
     private EntityRepositoryInterface $salesChannelRepository;
     private EntityRepositoryInterface $mediaFolderRepository;
+    private MediaUtils $mediaUtils;
 
     public function __construct(
         EntityRepositoryInterface $currencyRepository,
@@ -41,7 +43,8 @@ class FixtureHelper
         EntityRepositoryInterface $cmsPageRepository,
         EntityRepositoryInterface $taxRepository,
         EntityRepositoryInterface $salesChannelRepository,
-        EntityRepositoryInterface $mediaFolderRepository
+        EntityRepositoryInterface $mediaFolderRepository,
+        MediaUtils $mediaUtils
     ) {
         $this->currencyRepository       = $currencyRepository;
         $this->paymentMethodRepository  = $paymentMethodRepository;
@@ -55,6 +58,7 @@ class FixtureHelper
         $this->taxRepository            = $taxRepository;
         $this->salesChannelRepository   = $salesChannelRepository;
         $this->mediaFolderRepository    = $mediaFolderRepository;
+        $this->mediaUtils               = $mediaUtils;
     }
 
     public function getEuroCurrencyId(): ?string
@@ -241,5 +245,14 @@ class FixtureHelper
         return $this->categoryRepository
             ->searchIds($criteria, Context::createDefaultContext())
             ->firstId();
+    }
+
+    /**
+     * Use this to access the media related features
+     * of the fixture helper class.
+     */
+    public function Media(): MediaUtils
+    {
+        return $this->mediaUtils;
     }
 }

--- a/src/Utils/MediaUtils.php
+++ b/src/Utils/MediaUtils.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Basecom\FixturePlugin\Utils;
+
+use Shopware\Core\Content\Media\File\FileFetcher;
+use Shopware\Core\Content\Media\File\FileSaver;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+
+class MediaUtils
+{
+    private EntityRepositoryInterface $mediaRepository;
+    private FileSaver $fileSaver;
+    private FileFetcher $fileFetcher;
+
+    public function __construct(EntityRepositoryInterface $mediaRepository, FileSaver $fileSaver, FileFetcher $fileFetcher)
+    {
+        $this->mediaRepository = $mediaRepository;
+        $this->fileSaver       = $fileSaver;
+        $this->fileFetcher     = $fileFetcher;
+    }
+
+    public function upload(string $mediaId, string $folderId, string $filename, string $extension, string $contentType): void
+    {
+        $ctx = Context::createDefaultContext();
+
+        $this->mediaRepository->upsert([
+            [
+                'id'            => $mediaId,
+                'mediaFolderId' => $folderId,
+            ],
+        ],
+            $ctx
+        );
+
+        $uploadedFile = $this->fileFetcher->fetchBlob(
+            (string) file_get_contents($filename),
+            $extension,
+            $contentType
+        );
+
+        $this->fileSaver->persistFileToMedia(
+            $uploadedFile,
+            basename($filename, '.'.$extension),
+            $mediaId,
+            $ctx
+        );
+    }
+}


### PR DESCRIPTION
proposal pull request, please check if you like it

building a media upload helper to automatically insert local assets from the fixture folder as cover images or other media

```php
$this->helper->Media()->upload(
    self::MEDIA_ID,
    $this->helper->getMediaDefaultFolderId('product'),
     __DIR__ . '/Assets/voucher-product.png',
    'png',
    'image/png',
);
```

<img width="1169" alt="Screen Shot 2022-07-27 at 23 48 02" src="https://user-images.githubusercontent.com/5579326/181378611-afa9b162-d115-4dfa-9a46-a30d1d96bac6.png">
