### PR TITLE
Restore Shopware 6.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2023-05-26
+
+### Fixed
+
+- Restored compatibility for Shopware 6.4 by removing typehints for **EntityRepository** in util classes.
+
 ## [2.2.0] - 2023-05-09
 ### Added
 - Added tests for PHP 8.2
@@ -120,6 +126,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getNotSpecifiedSalutationId`
   - `getGermanCountryId`
 
+[2.2.1]: https://github.com/basecom/FixturesPlugin/compare/2.2.0...2.2.1
+[2.2.0]: https://github.com/basecom/FixturesPlugin/compare/2.1.0...2.2.0
+[2.1.0]: https://github.com/basecom/FixturesPlugin/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/basecom/FixturesPlugin/compare/1.8.0...2.0.0
 [1.8.0]: https://github.com/basecom/FixturesPlugin/compare/1.7.0...1.8.0
 [1.7.0]: https://github.com/basecom/FixturesPlugin/compare/1.6.0...1.7.0

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -15,3 +15,12 @@ services:
     Basecom\FixturePlugin\FixtureLoader:
         arguments:
             - !tagged_iterator basecom.fixture
+
+    Basecom\FixturePlugin\Utils\MediaUtils:
+        arguments:
+            $mediaRepository: '@media.repository'
+            $mediaFolderRepository: '@media_folder.repository'
+
+    Basecom\FixturePlugin\Utils\PaymentMethodUtils:
+        arguments:
+            $paymentMethodRepository: '@payment_method.repository'

--- a/src/Utils/MediaUtils.php
+++ b/src/Utils/MediaUtils.php
@@ -14,12 +14,31 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
 class MediaUtils
 {
-    private EntityRepository $mediaRepository;
-    private EntityRepository $mediaFolderRepository;
+    /**
+     * @TODO Replace with real typehint when Shopware 6.4 support is dropped.
+     *
+     * @var EntityRepository
+     */
+    private $mediaRepository;
+
+    /**
+     * @TODO Replace with real typehint when Shopware 6.4 support is dropped.
+     *
+     * @var EntityRepository
+     */
+    private $mediaFolderRepository;
     private FileSaver $fileSaver;
     private FileFetcher $fileFetcher;
 
-    public function __construct(EntityRepository $mediaRepository, EntityRepository $mediaFolderRepository, FileSaver $fileSaver, FileFetcher $fileFetcher)
+    /**
+     * @TODO Replace with real typehints when Shopware 6.4 support is dropped.
+     *
+     * @param EntityRepository $mediaRepository
+     * @param EntityRepository $mediaFolderRepository
+     *
+     * @noinspection PhpMissingParamTypeInspection We can not use typehints until repository decorators are removed (Shopware 6.5).
+     */
+    public function __construct($mediaRepository, $mediaFolderRepository, FileSaver $fileSaver, FileFetcher $fileFetcher)
     {
         $this->mediaRepository       = $mediaRepository;
         $this->mediaFolderRepository = $mediaFolderRepository;

--- a/src/Utils/PaymentMethodUtils.php
+++ b/src/Utils/PaymentMethodUtils.php
@@ -13,9 +13,21 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
 class PaymentMethodUtils
 {
-    private EntityRepository $paymentMethodRepository;
+    /**
+     * @TODO Replace with real typehint when Shopware 6.4 support is dropped.
+     *
+     * @var EntityRepository
+     */
+    private $paymentMethodRepository;
 
-    public function __construct(EntityRepository $paymentMethodRepository)
+    /**
+     * @TODO Replace with real typehint when Shopware 6.4 support is dropped.
+     *
+     * @param EntityRepository $paymentMethodRepository
+     *
+     * @noinspection PhpMissingParamTypeInspection We can not use typehints until PaymentMethodRepositoryDecorator is removed (Shopware 6.5).
+     */
+    public function __construct($paymentMethodRepository)
     {
         $this->paymentMethodRepository = $paymentMethodRepository;
     }


### PR DESCRIPTION
Remove typehints for `EntityRepository` from `MediaUtils` and `PaymentMethodUtils`.

Shopware 6.4 provides decorators for these repos
that implement the deprecated EntityRepositoryInterface:

```
\Shopware\Core\Content\Media\DataAbstractionLayer\MediaRepositoryDecorator
\Shopware\Core\Content\Media\DataAbstractionLayer\MediaFolderRepositoryDecorator
\Shopware\Core\Checkout\Payment\DataAbstractionLayer\PaymentMethodRepositoryDecorator
```

As long as these decorators exist the typehint for the new `EntityRepository` class will break.