### PR TITLE
Change taxValue type from int to float in SalesChannelUtils to match DAL type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--dry` option to all fixture load commands
     - This option will prevent the fixtures from being executed but still prints all fixtures it would execute
 
+### Changed
+- Changed argument type on `SalesChannelUtils::getTax()` from `int` to `float`
+
 ### Removed
 - Dropped support for PHP 8.1
 - Dropped support for Shopware 6.3 & 6.4

--- a/src/Utils/SalesChannelUtils.php
+++ b/src/Utils/SalesChannelUtils.php
@@ -136,7 +136,7 @@ readonly class SalesChannelUtils
         return $tax instanceof TaxEntity ? $tax : null;
     }
 
-    public function getTax(int $taxValue): ?TaxEntity
+    public function getTax(float $taxValue): ?TaxEntity
     {
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('taxRate', $taxValue))


### PR DESCRIPTION
Currently the argument type of `SalesChannelUtils::getTax()` is set to `int`, while the DAL definition sets it as `float` on the database level.

This change is not strictly breaking (except for type checks by linters and the like), as PHP will implicitly cast the type from then `int` to now `float`.

See [Type juggling in function contexts](https://www.php.net/manual/en/language.types.type-juggling.php#language.types.type-juggling.function):

> In this context the value must be a value of the type. Two exceptions exist, the first one is: if the value is of type [int](https://www.php.net/manual/en/language.types.integer.php) and the declared type is [float](https://www.php.net/manual/en/language.types.float.php), then the integer is converted to a floating point number.
