### PR TITLE
Add FixtureInterface to avoid readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ Create a new file in the specific folder of your project for the fixtures and ex
 Then just implement the "**load()**" method with fixture logic.
 
 ```php 
-class CustomerFixture extends Fixture
+readonly class CustomerFixture extends Fixture
 {
     /**
-     * @param FixtureBag $bag
      * @return void
      */
-    public function load(FixtureBag $bag): void
+    public function load(): void
     {
         // custom code 
     }

--- a/_examples/CategoryFixture.php
+++ b/_examples/CategoryFixture.php
@@ -7,7 +7,7 @@ namespace Basecom\FixturePlugin;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 
-class CategoryFixture extends Fixture
+readonly class CategoryFixture extends Fixture
 {
     private FixtureHelper $helper;
     private EntityRepositoryInterface $categoryRepository;
@@ -18,7 +18,7 @@ class CategoryFixture extends Fixture
         $this->categoryRepository = $categoryRepository;
     }
 
-    public function load(FixtureBag $bag): void
+    public function load(): void
     {
         $this->categoryRepository->upsert([
             [

--- a/_examples/CustomerFixture.php
+++ b/_examples/CustomerFixture.php
@@ -7,7 +7,7 @@ namespace Basecom\FixturePlugin;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 
-class CustomerFixture extends Fixture
+readonly class CustomerFixture extends Fixture
 {
     private const CUSTOMER_ID = '0d8eefdd6d32456385580e2ff42431b9';
     private const ADDRESS_ID  = 'e27dc2b4e85f4a0f9a912a09f07701b0';
@@ -21,7 +21,7 @@ class CustomerFixture extends Fixture
         $this->customerRepository = $customerRepository;
     }
 
-    public function load(FixtureBag $bag): void
+    public function load(): void
     {
         $salesChannel = $this->helper->SalesChannel()->getStorefrontSalesChannel();
 

--- a/_examples/ProductFixture.php
+++ b/_examples/ProductFixture.php
@@ -7,7 +7,7 @@ namespace Basecom\FixturePlugin;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 
-class ProductFixture extends Fixture
+readonly class ProductFixture extends Fixture
 {
     private const MEDIA_ID   = '0d2ccefd6d22436385580e2ff42431b9';
     private const PRODUCT_ID = '0d8ffedd6d22436385580e2ff42431b9';
@@ -22,7 +22,7 @@ class ProductFixture extends Fixture
         $this->repoProducts = $repoProducts;
     }
 
-    public function load(FixtureBag $bag): void
+    public function load(): void
     {
         $this->helper->Media()->upload(
             self::MEDIA_ID,

--- a/src/Fixture.php
+++ b/src/Fixture.php
@@ -4,24 +4,9 @@ declare(strict_types=1);
 
 namespace Basecom\FixturePlugin;
 
-abstract readonly class Fixture
+abstract readonly class Fixture implements FixtureInterface
 {
     abstract public function load(): void;
-
-    /** @return string[] */
-    public function dependsOn(): array
-    {
-        return [];
-    }
-
-    public function priority(): int
-    {
-        return 0;
-    }
-
-    /** @return string[] */
-    public function groups(): array
-    {
-        return [];
-    }
+    
+    use FixtureAwareTrait;
 }

--- a/src/FixtureAwareTrait.php
+++ b/src/FixtureAwareTrait.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Basecom\FixturePlugin;
+
+trait FixtureAwareTrait
+{
+
+    /** @return string[] */
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    public function priority(): int
+    {
+        return 0;
+    }
+
+    /** @return string[] */
+    public function groups(): array
+    {
+        return [];
+    }
+}

--- a/src/FixtureInterface.php
+++ b/src/FixtureInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Basecom\FixturePlugin;
+
+interface FixtureInterface
+{
+    public function load(): void;
+
+    /** @return string[] */
+    public function dependsOn(): array;
+
+    public function priority(): int;
+
+    /** @return string[] */
+    public function groups(): array;
+}


### PR DESCRIPTION
Hi All,

in this pr i added a FixtureInterface because the readonly part is not supported in PHP 7.4 and PHP 8.1. this is a Problem for us since we need to have fixtures in those versions.

i could checkout different branches based on shopware version but then all my fixture classes have to be changed and i have to load different classes for different shopware versions. i would rather use one class base which works on all shopware version.

i was not sure why the class has to be readonly thats why i added the interface. 

if you dont need readonly then i can change the pr.

