### PR TITLE
Add support for PHP8.5

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,83 +1,83 @@
 name: Linting
 on: [push]
 jobs:
-    php-cs-fixer:
-        name: PHP-CS-Fixer
-        runs-on: ubuntu-latest
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
 
-        strategy:
-            matrix:
-                php-version: [ 8.2, 8.3 , 8.4]
+    strategy:
+      matrix:
+        php-version: [8.2, 8.3, 8.4, 8.5]
 
-        steps:
-            -   name: Set up PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
 
-            -   name: Check out code
-                uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-            -   name: Cache Composer packages
-                id: composer-cache
-                uses: actions/cache@v4
-                with:
-                    path: vendor
-                    key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-            -   name: Install dependencies
-                run: 'composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader'
+      - name: Install dependencies
+        run: "composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader"
 
-            -   name: Run PHP CS Fixer
-                run: 'PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer check'
+      - name: Run PHP CS Fixer
+        run: "PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer check"
 
-    phpstan:
-        name: PHPStan
-        runs-on: ubuntu-latest
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
 
-        strategy:
-            matrix:
-                php-version: [ 8.2, 8.3, 8.4 ]
-                composer-strategy: [ lowest, stable ]
+    strategy:
+      matrix:
+        php-version: [8.2, 8.3, 8.4, 8.5]
+        composer-strategy: [lowest, stable]
 
-        steps:
-            -   name: Set up PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
 
-            -   name: Check out code
-                uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-            -   name: Cache Composer packages
-                id: composer-cache
-                uses: actions/cache@v4
-                with:
-                    path: vendor
-                    key: ${{ runner.os }}-php-strategy-${{ matrix.composer-strategy }}-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-strategy-${{ matrix.composer-strategy }}-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-strategy-${{ matrix.composer-strategy }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-strategy-${{ matrix.composer-strategy }}-
 
-            -   name: Install dependencies
-                run: 'composer update -W --prefer-${{ matrix.composer-strategy }} --no-ansi --no-interaction --no-progress --optimize-autoloader'
+      - name: Install dependencies
+        run: "composer update -W --prefer-${{ matrix.composer-strategy }} --no-ansi --no-interaction --no-progress --optimize-autoloader"
 
-            -   name: Run PHPStan
-                run: './vendor/bin/phpstan analyse --memory-limit=1G'
+      - name: Run PHPStan
+        run: "./vendor/bin/phpstan analyse --memory-limit=1G"
 
-    prettier:
-        name: Prettier
-        runs-on: ubuntu-latest
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
 
-        steps:
-            -   name: Check out code
-                uses: actions/checkout@v4
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-            - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v1
 
-            -   name: Install dependencies
-                run: bun install
+      - name: Install dependencies
+        run: bun install
 
-            -   name: Run Prettier
-                run: './node_modules/.bin/prettier --check "src/**/*.{js,scss,yaml,yml,json,md,ts}"'
+      - name: Run Prettier
+        run: './node_modules/.bin/prettier --check "src/**/*.{js,scss,yaml,yml,json,md,ts}"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] - 2026-04-24
+### Added
+- Added support for PHP 8.4
+
 ## [3.2.1] - 2025-11-10
 ### Fixed
 - Admin build issue in Shopware 6.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.2.2] - 2026-04-24
 ### Added
-- Added support for PHP 8.4
+- Added support for PHP 8.5
 
 ## [3.2.1] - 2025-11-10
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,53 @@
 {
-    "name": "basecom/sw6-fixtures-plugin",
-    "description": "basecom Fixtures Plugin",
-    "type": "shopware-platform-plugin",
-    "license": "proprietary",
-    "authors": [
-        {
-            "name": "basecom GmbH & Co. KG",
-            "email": "info@basecom.de",
-            "homepage": "https://basecom.de",
-            "role": "Manufacturer"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "Basecom\\FixturePlugin\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Basecom\\FixturePlugin\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "shopware-plugin-class": "Basecom\\FixturePlugin\\BasecomFixturePlugin",
-        "label": {
-            "de-DE": "basecom Fixture Plugin",
-            "en-GB": "basecom Fixture Plugin"
-        },
-        "copyright": "(c) basecom GmbH & Co. KG",
-        "plugin-icon": "src/Resources/config/plugin.png",
-        "description": {
-            "de-DE": "Erlaubt das Generieren von Demo-Daten",
-            "en-GB": "Allows the generation of demo data"
-        }
-    },
-    "require": {
-        "php": "^8.2 || ^8.3 ||^8.4",
-        "shopware/core": "6.5.*|6.6.*|6.7.*",
-        "shopware/administration": "6.5.*|6.6.*|6.7.*",
-        "shopware/storefront": "6.5.*|6.6.*|6.7.*",
-        "spatie/once": "^3.1"
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "3.93.0",
-        "phpstan/phpstan": "^2.1.17"
-    },
-    "config": {
-        "allow-plugins": {
-            "symfony/runtime": true
-        }
-    }
+	"name": "basecom/sw6-fixtures-plugin",
+	"description": "basecom Fixtures Plugin",
+	"type": "shopware-platform-plugin",
+	"license": "proprietary",
+	"authors": [
+		{
+			"name": "basecom GmbH & Co. KG",
+			"email": "info@basecom.de",
+			"homepage": "https://basecom.de",
+			"role": "Manufacturer"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"Basecom\\FixturePlugin\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Basecom\\FixturePlugin\\Tests\\": "tests/"
+		}
+	},
+	"extra": {
+		"shopware-plugin-class": "Basecom\\FixturePlugin\\BasecomFixturePlugin",
+		"label": {
+			"de-DE": "basecom Fixture Plugin",
+			"en-GB": "basecom Fixture Plugin"
+		},
+		"copyright": "(c) basecom GmbH & Co. KG",
+		"plugin-icon": "src/Resources/config/plugin.png",
+		"description": {
+			"de-DE": "Erlaubt das Generieren von Demo-Daten",
+			"en-GB": "Allows the generation of demo data"
+		}
+	},
+	"require": {
+		"php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
+		"shopware/core": "6.5.*|6.6.*|6.7.*",
+		"shopware/administration": "6.5.*|6.6.*|6.7.*",
+		"shopware/storefront": "6.5.*|6.6.*|6.7.*",
+		"spatie/once": "^3.1"
+	},
+	"require-dev": {
+		"friendsofphp/php-cs-fixer": "3.93.0",
+		"phpstan/phpstan": "^2.1.17"
+	},
+	"config": {
+		"allow-plugins": {
+			"symfony/runtime": true
+		}
+	}
 }

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -2,14 +2,14 @@
 
 Please use the following table to check which version of the FixturePlugin can be used with your PHP and Shopware versions:
 
-| Shopware Version | PHP Versions     | Newest FixturePlugin version | Supported |
-| ------------------ | --------------   | ------------------------------ | ----------- |
-| 6.7.*            | v8.2, v8.3, v8.4 | v3.2.*                       | ✅         |
-| 6.6.*            | v8.2, v8.3       | v3.2.*                       | ✅         |
-| 6.5.*            | v8.2, v8.3       | v3.2.*                       | ✅         |
-| 6.5.*            | v8.1             | v2.0.*                       | ❌         |
-| 6.4.*            | v8.1, v8.2       | v2.0.*                       | ❌         |
-| 6.3.*            | v8.1, v8.2       | v2.0.*                       | ❌         |
+| Shopware Version | PHP Versions           | Newest FixturePlugin version | Supported |
+| ---------------- | ---------------------- | ---------------------------- | --------- |
+| 6.7.*            | v8.2, v8.3, v8.4, v8.5 | v3.2.*                       | ✅        |
+| 6.6.*            | v8.2, v8.3             | v3.2.*                       | ✅        |
+| 6.5.*            | v8.2, v8.3             | v3.2.*                       | ✅        |
+| 6.5.*            | v8.1                   | v2.0.*                       | ❌        |
+| 6.4.*            | v8.1, v8.2             | v2.0.*                       | ❌        |
+| 6.3.*            | v8.1, v8.2             | v2.0.*                       | ❌        |
 
 :::info
 We strive to support new Shopware and PHP versions as quickly as possible. If there is a new version out and it is not yet supported, feel free to contribute and help us expedite the update process!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI matrix updated to include PHP 8.5.

* **Chores**
  * Package requirements updated to include PHP 8.5.
  * CI and config files reformatted for consistency.

* **Documentation**
  * Compatibility matrix updated to show PHP 8.5 support for the current release line.

* **Changelog**
  * Added 3.2.2 release entry noting PHP 8.5 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->